### PR TITLE
Hotfix/refuse verification

### DIFF
--- a/artists-heaven-backend/src/main/java/com/artists_heaven/entities/artist/ArtistController.java
+++ b/artists-heaven-backend/src/main/java/com/artists_heaven/entities/artist/ArtistController.java
@@ -40,7 +40,7 @@ public class ArtistController {
     public ResponseEntity<Artist> registerArtist(@ModelAttribute ArtistRegisterDTO request) {
 
         try {
-            String imageUrl = imageServingUtil.saveImages(request.getImage(), UPLOAD_DIR, "/mainArtist_media/");
+            String imageUrl = imageServingUtil.saveImages(request.getImage(), UPLOAD_DIR, "/mainArtist_media/", false);
             Artist registeredArtist = new Artist();
             registeredArtist.setMainViewPhoto(imageUrl);
 

--- a/artists-heaven-backend/src/main/java/com/artists_heaven/event/EventController.java
+++ b/artists-heaven-backend/src/main/java/com/artists_heaven/event/EventController.java
@@ -82,7 +82,7 @@ public class EventController {
                 Artist artist = (Artist) principalUser;
                 eventDTO.setArtistId(artist.getId());
 
-                String imageUrls = imageServingUtil.saveImages(image, UPLOAD_DIR, "/event_media/");
+                String imageUrls = imageServingUtil.saveImages(image, UPLOAD_DIR, "/event_media/", false);
                 eventDTO.setImage(imageUrls);
 
                 Event newEvent = eventService.newEvent(eventDTO);
@@ -210,7 +210,7 @@ public class EventController {
             // If a new image is provided, delete the old image and save the new one
             if (newImage != null) {
                 eventService.deleteImages(event.getImage()); // Deleting old image
-                String imageUrl = imageServingUtil.saveImages(newImage, UPLOAD_DIR, "/event_media/"); // Saving new image
+                String imageUrl = imageServingUtil.saveImages(newImage, UPLOAD_DIR, "/event_media/", false); // Saving new image
                 eventDTO.setImage(imageUrl); // Setting the new image URL in eventDTO
             }
 

--- a/artists-heaven-backend/src/main/java/com/artists_heaven/verification/VerificationController.java
+++ b/artists-heaven-backend/src/main/java/com/artists_heaven/verification/VerificationController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import com.artists_heaven.email.EmailSenderService;
 import com.artists_heaven.entities.artist.Artist;
+import com.artists_heaven.images.ImageServingUtil;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -25,11 +27,17 @@ public class VerificationController {
 
     private final VerificationService verificationService;
 
+    private final ImageServingUtil imageServingUtil;
+
     private final String ERROR = "error";
 
-    public VerificationController(EmailSenderService emailSenderService, VerificationService verificationService) {
+    private final String UPLOAD_DIR = "artists-heaven-backend/src/main/resources/verification_media";
+
+    public VerificationController(EmailSenderService emailSenderService, VerificationService verificationService,
+            ImageServingUtil imageServingUtil) {
         this.emailSenderService = emailSenderService;
         this.verificationService = verificationService;
+        this.imageServingUtil = imageServingUtil;
     }
 
     @PostMapping("/send")
@@ -63,7 +71,7 @@ public class VerificationController {
             }
 
             // Save the video file and create the verification request
-            String videoUrl = verificationService.saveFile(video);
+            String videoUrl = imageServingUtil.saveImages(video, UPLOAD_DIR, "/verification_media/", true);
             verificationService.createVerification(artist, videoUrl);
 
             // Send verification email

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/auth/AuthControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/auth/AuthControllerTest.java
@@ -8,12 +8,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -179,5 +181,10 @@ class AuthControllerTest {
                 .content(objectMapper.writeValueAsString(requestPayload)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Invalid ID token"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/auth/AuthServiceTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/auth/AuthServiceTest.java
@@ -10,12 +10,15 @@ import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.artists_heaven.configuration.JwtTokenProvider;
@@ -142,5 +145,10 @@ class AuthServiceTest {
     void testMapRoleToAuthority_Admin() throws Exception {
         String authority = (String) mapRoleToAuthorityMethod.invoke(authService, UserRole.ADMIN);
         assertEquals("ROLE_ADMIN", authority);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/entities/artist/ArtistControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/entities/artist/ArtistControllerTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.Files;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -75,7 +76,8 @@ class ArtistControllerTest {
                 Artist artist = new Artist();
                 artist.setMainViewPhoto("mianViewPhoto.jpg");
 
-                when(imageServingUtil.saveImages(image, "artists-heaven-backend/src/main/resources/mainArtist_media/", "/mainArtist_media/"))
+                when(imageServingUtil.saveImages(image, "artists-heaven-backend/src/main/resources/mainArtist_media/",
+                                "/mainArtist_media/", false))
                                 .thenReturn("mianViewPhoto.jpg");
                 when(artistService.registerArtist(any(), any())).thenReturn(artist);
 
@@ -97,7 +99,8 @@ class ArtistControllerTest {
                 MockMultipartFile image = new MockMultipartFile("image", "photo.jpg", "image/jpeg", "img".getBytes());
 
                 // Simular que el servicio lanza excepción por datos inválidos
-                when(imageServingUtil.saveImages(image, "artists-heaven-backend/src/main/resources/mainArtist_media/", "/mainArtist_media/"))
+                when(imageServingUtil.saveImages(image, "artists-heaven-backend/src/main/resources/mainArtist_media/",
+                                "/mainArtist_media/", false))
                                 .thenReturn("photo.jpg");
                 when(artistService.registerArtist(any(), any()))
                                 .thenThrow(new IllegalArgumentException("Invalid user data"));
@@ -247,6 +250,11 @@ class ArtistControllerTest {
 
                 // Limpieza
                 Files.deleteIfExists(imagePath);
+        }
+
+        @AfterEach
+        void tearDown() {
+                SecurityContextHolder.clearContext();
         }
 
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/entities/user/UserControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/entities/user/UserControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.security.Principal;
 import java.util.Collections;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.artists_heaven.entities.artist.Artist;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 class UserControllerTest {
 
@@ -134,6 +136,11 @@ class UserControllerTest {
                 mockMvc.perform(get("/api/users/profile").principal(principal))
                                 .andExpect(status().isOk())
                                 .andExpect(jsonPath("$.email").value("artist@email.com"));
+        }
+
+        @AfterEach
+        void tearDown() {
+                SecurityContextHolder.clearContext();
         }
 
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/entities/user/UserServiceTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/entities/user/UserServiceTest.java
@@ -9,12 +9,14 @@ import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.artists_heaven.entities.artist.Artist;
@@ -97,9 +99,12 @@ class UserServiceTest {
 
     @Test
     void testGetUserProfileException() {
-        Authentication authentication = mock(Authentication.class); when(authentication.getPrincipal()).thenReturn(null);
-         Exception exception = assertThrows(IllegalArgumentException.class, () -> { userService.getUserProfile(authentication); }); 
-        assertEquals("Usuario no autenticado", exception.getMessage()); 
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(null);
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            userService.getUserProfile(authentication);
+        });
+        assertEquals("Usuario no autenticado", exception.getMessage());
     }
 
     @Test
@@ -157,5 +162,10 @@ class UserServiceTest {
         assertEquals("NewLastName", artist.getLastName());
         assertEquals("NewArtistName", artist.getArtistName());
         verify(userRepository, times(1)).save(artist);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/event/EventControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/event/EventControllerTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -98,7 +99,8 @@ class EventControllerTest {
                 when(authentication.getPrincipal()).thenReturn(artist);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
-                when(imageServingUtil.saveImages(image, UPLOAD_DIR, "/event_media/")).thenReturn("/product_media/test.jpg");
+                when(imageServingUtil.saveImages(image, UPLOAD_DIR, "/event_media/", false))
+                                .thenReturn("/product_media/test.jpg");
                 when(eventService.newEvent(any(EventDTO.class))).thenReturn(new Event());
 
                 MockMultipartFile eventJson = new MockMultipartFile("event", "", "application/json",
@@ -110,7 +112,7 @@ class EventControllerTest {
                                 .file(image))
                                 .andExpect(status().isCreated());
 
-                verify(imageServingUtil, times(1)).saveImages(image, UPLOAD_DIR, "/event_media/");
+                verify(imageServingUtil, times(1)).saveImages(image, UPLOAD_DIR, "/event_media/", false);
                 verify(eventService, times(1)).newEvent(any(EventDTO.class));
         }
 
@@ -138,7 +140,7 @@ class EventControllerTest {
                                 .file(image))
                                 .andExpect(status().isBadRequest());
 
-                verify(imageServingUtil, times(0)).saveImages(image, UPLOAD_DIR, "/event_media/");
+                verify(imageServingUtil, times(0)).saveImages(image, UPLOAD_DIR, "/event_media/", false);
                 verify(eventService, times(0)).newEvent(any(EventDTO.class));
                 SecurityContextHolder.clearContext();
         }
@@ -333,7 +335,7 @@ class EventControllerTest {
 
                 verify(eventService, times(1)).isArtist();
                 verify(eventService, times(1)).getEventById(1L);
-                verify(imageServingUtil, times(1)).saveImages(image, UPLOAD_DIR, "/event_media/");
+                verify(imageServingUtil, times(1)).saveImages(image, UPLOAD_DIR, "/event_media/", false);
                 verify(eventService, times(1)).updateEvent(any(Event.class), any(EventDTO.class));
         }
 
@@ -440,6 +442,11 @@ class EventControllerTest {
 
                 mockMvc.perform(get("/api/event/event_media/" + fileName))
                                 .andExpect(status().isNotFound());
+        }
+
+        @AfterEach
+        void tearDown() {
+                SecurityContextHolder.clearContext();
         }
 
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/event/EventServiceTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/event/EventServiceTest.java
@@ -3,26 +3,23 @@ package com.artists_heaven.event;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,8 +29,6 @@ import com.artists_heaven.entities.artist.ArtistRepository;
 import com.artists_heaven.images.ImageServingUtil;
 
 class EventServiceTest {
-
-    private static final String UPLOAD_DIR = "artists-heaven-backend/src/main/resources/event_media/";
 
     @Mock
     private EventRepository eventRepository;
@@ -170,7 +165,6 @@ class EventServiceTest {
         assertNotNull(event);
         verify(eventRepository, times(1)).save(any(Event.class));
     }
-
 
     @Test
     void testDeleteEventSuccess() {
@@ -355,5 +349,10 @@ class EventServiceTest {
 
         assertEquals("Event date cannot be in the past", exception.getMessage());
         verify(eventRepository, times(0)).save(event);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/images/ImageServingUtilTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/images/ImageServingUtilTest.java
@@ -61,7 +61,7 @@ class ImageServingUtilTest {
                 "image", "photo.png", "image/png", content);
 
         // Act
-        String imageUrl = imageServingUtil.saveImages(multipartFile, basePath, "/imageUrlCode/");
+        String imageUrl = imageServingUtil.saveImages(multipartFile, basePath, "/imageUrlCode/",false);
 
         // Assert
         assertNotNull(imageUrl);
@@ -78,7 +78,7 @@ class ImageServingUtilTest {
 
         // Act + Assert
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> imageServingUtil.saveImages(file, basePath, "/imageUrlCode/"));
+                () -> imageServingUtil.saveImages(file, basePath, "/imageUrlCode/",false));
 
         assertTrue(ex.getMessage().contains("not a valid image"));
     }
@@ -91,7 +91,7 @@ class ImageServingUtilTest {
 
         // Act + Assert
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> imageServingUtil.saveImages(file, basePath, "/imageUrlCode/"));
+                () -> imageServingUtil.saveImages(file, basePath, "/imageUrlCode/",false));
 
         assertTrue(ex.getMessage().contains("not a valid image"));
     }
@@ -104,7 +104,7 @@ class ImageServingUtilTest {
 
         // Act + Assert
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> imageServingUtil.saveImages(file, basePath, "/imageUrlCode/"));
+                () -> imageServingUtil.saveImages(file, basePath, "/imageUrlCode/",false));
 
         assertTrue(ex.getMessage().contains("file name is invalid"));
     }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/order/OrderControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/order/OrderControllerTest.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -228,5 +229,10 @@ class OrderControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound()); // Verificamos que el status sea 404 NOT
 
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/paymentGateway/PaymentGatewayControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/paymentGateway/PaymentGatewayControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -113,5 +114,10 @@ class PaymentGatewayControllerTest {
                 .header("Stripe-Signature", sigHeader)
                 .content(payload))
                 .andExpect(status().isOk());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/paymentGateway/PaymentGatewayServiceTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/paymentGateway/PaymentGatewayServiceTest.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -152,6 +154,11 @@ class PaymentGatewayServiceTest {
 
         // Verificación de que el resultado no es nulo y contiene la URL de éxito
         assertNotNull(result);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/product/ProductControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/product/ProductControllerTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -612,5 +613,10 @@ class ProductControllerTest {
                 mockMvc.perform(get("/api/product/sorted12Product")
                                 .accept(MediaType.APPLICATION_JSON))
                                 .andExpect(status().isNotFound());
+        }
+
+        @AfterEach
+        void tearDown() {
+                SecurityContextHolder.clearContext();
         }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/rating/RatingControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/rating/RatingControllerTest.java
@@ -1,5 +1,8 @@
 package com.artists_heaven.rating;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -8,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -108,5 +112,10 @@ class RatingControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(new ObjectMapper().writeValueAsString(ratingRequestDTO)))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/returns/ReturnControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/returns/ReturnControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -172,6 +173,11 @@ class ReturnControllerTest {
         when(orderService.findOrderById(orderId)).thenReturn(order);
 
         ResponseEntity<byte[]> response = returnController.getReturnLabel(orderId, null);
-         assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/shoppingCart/ShoppingCartControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/shoppingCart/ShoppingCartControllerTest.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -409,6 +410,11 @@ class ShoppingCartControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                                 .andExpect(status().isInternalServerError()); // 500
+        }
+
+        @AfterEach
+        void tearDown() {
+                SecurityContextHolder.clearContext();
         }
 
 }

--- a/artists-heaven-backend/src/test/java/com/artists_heaven/verification/VerificationControllerTest.java
+++ b/artists-heaven-backend/src/test/java/com/artists_heaven/verification/VerificationControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 import com.artists_heaven.email.EmailSenderService;
 import com.artists_heaven.entities.artist.Artist;
+import com.artists_heaven.images.ImageServingUtil;
 
 class VerificationControllerTest {
 
@@ -25,8 +26,13 @@ class VerificationControllerTest {
     @Mock
     private VerificationService verificationService;
 
+    @Mock
+    private ImageServingUtil imageServingUtil;
+
     @InjectMocks
     private VerificationController verificationController;
+
+    private final String UPLOAD_DIR = "artists-heaven-backend/src/main/resources/verification_media";
 
     @BeforeEach
     void setUp() {
@@ -87,7 +93,7 @@ class VerificationControllerTest {
         when(verificationService.validateArtist(email)).thenReturn(artist);
         when(verificationService.isArtistEligibleForVerification(artist)).thenReturn(true);
         when(verificationService.hasPendingVerification(artist)).thenReturn(false);
-        when(verificationService.saveFile(video)).thenReturn(videoUrl);
+        when(imageServingUtil.saveImages(video, UPLOAD_DIR, "/verification_media/", true)).thenReturn(videoUrl);
 
         ResponseEntity<Map<String, Object>> response = verificationController.sendValidation(email, video);
 

--- a/artists-heaven-frontend/src/components/admin/AdminClients.js
+++ b/artists-heaven-frontend/src/components/admin/AdminClients.js
@@ -205,6 +205,30 @@ const AdminClient = () => {
             });
     };
 
+    const refuseArtist = (verificationId) => {
+        if (role !== "ADMIN") {
+            return;
+        }
+        fetch(`/api/admin/${verificationId}/refuse`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${authToken}`
+            },
+        })
+            .then(response => {
+                if (response.ok) {
+                    window.location.reload()
+                } else {
+                    console.log('Error al rechazar la verificación del artista');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+            });
+    };
+
+
     useEffect(() => {
         window.scrollTo(0, 0);
     }, [page]);
@@ -240,6 +264,8 @@ const AdminClient = () => {
     if (role !== 'ADMIN') {
         return <NonAuthorise />;
     }
+
+    console.log(verifications)
 
     return (
         <div className="min-h-screen bg-gradient-to-r from-gray-300 to-white flex flex-col">
@@ -331,7 +357,7 @@ const AdminClient = () => {
                                         <th className="px-4 py-3 text-left">Video</th>
                                         <th className="px-4 py-3 text-left">Fecha</th>
                                         <th className="px-4 py-3 text-left">Estado</th>
-                                        <th className="px-4 py-3 text-left">Acciones</th>
+                                        <th className="px-4 py-3 text-center">Acciones</th>
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-gray-200">
@@ -349,22 +375,35 @@ const AdminClient = () => {
                                             </td>
                                             <td className="px-4 py-3">
                                                 <span className={`px-2 py-1 rounded text-xs font-semibold
-                                ${verification.status === 'PENDING'
+    ${verification.status === 'PENDING'
                                                         ? 'bg-yellow-100 text-yellow-700'
-                                                        : 'bg-green-100 text-green-700'}`}>
+                                                        : verification.status === 'REJECTED'
+                                                            ? 'bg-red-100 text-red-700'
+                                                            : 'bg-green-100 text-green-700'
+                                                    }`}>
                                                     {verification.status}
                                                 </span>
                                             </td>
-                                            <td className="px-4 py-3">
-                                                {!verification.artist?.isVerificated ? (
-                                                    <button
-                                                        onClick={() => verifyArtist(verification.artist.id, verification.id)}
-                                                        className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 transition"
-                                                    >
-                                                        Verificar
-                                                    </button>
+                                            <td className="px-4 py-3 text-center">
+                                                {verification.status == 'PENDING' ? (
+                                                    <>
+                                                        <button
+                                                            onClick={() => verifyArtist(verification.artist.id, verification.id)}
+                                                            className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 transition mr-2"
+                                                        >
+                                                            Verificar
+                                                        </button>
+                                                        {verification.status === 'PENDING' && (
+                                                            <button
+                                                                onClick={() => refuseArtist(verification.id)}
+                                                                className="px-3 py-1 text-sm bg-red-500 text-white rounded hover:bg-red-600 transition"
+                                                            >
+                                                                Rechazar
+                                                            </button>
+                                                        )}
+                                                    </>
                                                 ) : (
-                                                    <span className="text-gray-500 italic text-sm">Ya verificado</span>
+                                                    <span className="text-gray-500 italic text-sm">Sin acciones pendientes</span>
                                                 )}
                                             </td>
                                         </tr>

--- a/artists-heaven-frontend/src/components/admin/AdminHeader.js
+++ b/artists-heaven-frontend/src/components/admin/AdminHeader.js
@@ -137,7 +137,7 @@ const AdminHeader = () => {
                     display: "inline-block",
                 }}
             >
-                <FontAwesomeIcon icon={faUser} size="xl" />
+                <FontAwesomeIcon icon={faUser} />
             </div>
 
 

--- a/artists-heaven-frontend/src/components/artist/ArtistHeader.js
+++ b/artists-heaven-frontend/src/components/artist/ArtistHeader.js
@@ -148,7 +148,7 @@ const ArtistHeader = () => {
                     display: "inline-block",
                 }}
             >
-                <FontAwesomeIcon icon={faUser} size="xl" />
+                <FontAwesomeIcon icon={faUser} />
             </div>
 
 

--- a/artists-heaven-frontend/src/components/charts/SalesChart.js
+++ b/artists-heaven-frontend/src/components/charts/SalesChart.js
@@ -33,6 +33,8 @@ const SalesChart = ({ year }) => {
             });
     }, [year, authToken]);
 
+    console.log(salesData)
+
     return (
         <ResponsiveContainer width="100%" height={400}>
             <AreaChart data={salesData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
@@ -52,7 +54,7 @@ const SalesChart = ({ year }) => {
                 <Tooltip />
                 <Legend />
                 <Area type="monotone" dataKey="totalOrders" name="Ventas Realizadas" stroke="#8884d8" fillOpacity={1} fill="url(#colorOrders)" />
-                {role === 'ADMIN' && (
+                {role === 'admin' && (
                     <Area
                         type="monotone"
                         dataKey="totalRevenue"


### PR DESCRIPTION
### Description

This Pull Request introduces a new feature that allows users or administrators to refuse verifications. It also includes improvements to image handling related to the verification process. Additionally, new tests were added to validate this functionality, and the SecurityContextHolder is now cleared after each test to prevent interference between test case

### Type of change

- [x] **New feature (feat)**: A new feature is added.
- [ ] **Bug fix (fix)**: Issues or bugs are resolved.
- [x] **Code refactor (refactor)**: Changes in the code that do not affect functionality.
- [ ] **Documentation (docs)**: Changes to the project documentation.
- [x] **Tests (test)**: Tests are added or modified.
- [ ] **Other**: _(please specify if necessary)_

### Expected behavior

After this PR:
- Admins can refuse verifications as part of the verification flow.
- Image handling during verification is improved and more robust.

### Changes made

- Added functionality to refuse a verification request.
-  Improved image handling logic in the verification process.
- Added new tests to validate the refuse verification functionality.
-  Introduced tearDown method to clear the SecurityContextHolder after each test.

### Checklist

- [x] The code follows the project's conventions (method names, coding style, etc.).
- [x] I have performed local tests before creating the PR.
- [ ] Documentation has been updated (if applicable).
- [x] Tests are complete and working correctly.

### Related Issue(s)
Closes #100 
